### PR TITLE
LRT559 error fix

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -1,6 +1,11 @@
 import paho.mqtt.client as mqtt
 
-import ltr559
+try:
+    # Transitional fix for breaking change in LTR559
+    from ltr559 import LTR559
+    ltr559 = LTR559()
+except ImportError:
+    import ltr559
 
 from bme280 import BME280
 from pms5003 import PMS5003


### PR DESCRIPTION
For the following error:
Traceback (most recent call last):
  File "main.py", line 58, in <module>
    main()
  File "main.py", line 40, in main
    logger.update(publish_readings=False)
  File "/usr/src/enviroplus-mqtt/src/logger.py", line 83, in update
    self.samples.append(self.take_readings())
  File "/usr/src/enviroplus-mqtt/src/logger.py", line 62, in take_readings
    "proximity": ltr559.get_proximity(),
AttributeError: module 'ltr559' has no attribute 'get_proximity'

Used the code from fix from pimoroni:
https://github.com/pimoroni/enviroplus-python/blob/master/examples/light.py